### PR TITLE
feat & refactoring & issue

### DIFF
--- a/internal/gaussian_splatting.py
+++ b/internal/gaussian_splatting.py
@@ -187,9 +187,6 @@ class GaussianSplatting(LightningModule):
         self.metric.setup(stage=stage, pl_module=self)
         self.density_controller.setup(stage=stage, pl_module=self)
 
-
-        print("222")
-        print(self.hparams["MLP"])
         if self.hparams["MLP"]==True:
             self.renderer.set_mlp(self.mlp_model)
         else:

--- a/internal/models/ciga_mlp.py
+++ b/internal/models/ciga_mlp.py
@@ -3,6 +3,7 @@ import pandas as pd
 import torch
 import torch.nn as nn
 import torch.optim as optim
+import torch.nn.functional as F
 from sklearn.datasets import load_breast_cancer
 
 # input : 위치: x, y, z / 거리(가우시안-카메라): s / 방향 : 카메라 dx, dy, dz
@@ -22,7 +23,7 @@ class CigaMLP(nn.Module):
       nn.ReLU(),
       nn.Linear(hidden, hidden, bias=True),
       nn.ReLU(),
-      nn.Linear(hidden, sh_max_degree, bias=True)
+      nn.Linear(hidden, sh_max_degree+1, bias=True)
     )
 
 
@@ -34,25 +35,16 @@ class CigaMLP(nn.Module):
     return cls(**kwargs)
   
   def to_input(self, camera, gaussian_pos):
-    """
-        print(f"cam_pos:{cam_pos.shape}\n"
-              f"{cam_pos}\n"
-              f"w2c:{cams.world_to_camera.shape}\n"
-              f"{cams.world_to_camera}\n")
-                     ->  campos는 카메라 중심 좌표 (배치가 1이라 shape이 3인거임)
-                            w2c의 왼쪽 상단 3*3은 회전 R, 3행 0열~2열 : t
-                             => 월드좌표계에서 카메라 좌표계로 변환할 때 사용
-        am_pos:torch.Size([3])
-        tensor([-5.5859e-03, -1.8000e+00, -2.1062e-13], device='cuda:0') 
-        w2c:torch.Size([4, 4])
-        tensor([[ 2.2204e-16,  0.0000e+00, -1.0000e+00,  0.0000e+00],
-                [ 0.0000e+00,  1.0000e+00,  0.0000e+00,  0.0000e+00],
-                [ 1.0000e+00,  0.0000e+00,  2.2204e-16,  0.0000e+00],
-                [ 2.1062e-13,  1.8000e+00, -5.5859e-03,  1.0000e+00]], device='cuda:0')
-        """
-    N, 3 = gaussian_pos.shape
-  
+    N = (gaussian_pos.shape)[0]
+    # 카메라 위치
     cam_pos = camera.camera_center
+    cam_pos = cam_pos.unsqueeze(0).expand(N, -1)
+    # 카메라-가우시안 거리
+    dis = (gaussian_pos - cam_pos).norm(dim=-1, keepdim=True)
 
-
-    return {'cam_pos': ,'dis': ,'dir': }
+    # 카메라-가우시안 방향
+    R = camera.world_to_camera[:3, :3]
+    dir = torch.tensor([0.0, 0.0, 1.0], device=gaussian_pos.device, dtype=gaussian_pos.dtype) @ R.t()
+    dir = F.normalize(dir, dim=0)
+    dir = F.normalize(gaussian_pos - cam_pos, dim=1)
+    return {'cam_pos': cam_pos, 'dis': dis, 'dir': dir}

--- a/internal/renderers/ciga_renderer2.py
+++ b/internal/renderers/ciga_renderer2.py
@@ -117,29 +117,6 @@ class CigaRenderer(Renderer):
             means3D, 
             L=pc.max_sh_degree
             )
-        
-        #test----------------------------------------------------------------
-        #cams = viewpoint_camera
-        #cam_pos = cams.camera_center
-        """
-        print(f"cam_pos:{cam_pos.shape}\n"
-              f"{cam_pos}\n"
-              f"w2c:{cams.world_to_camera.shape}\n"
-              f"{cams.world_to_camera}\n")
-                     ->  campos는 카메라 중심 좌표 (배치가 1이라 shape이 3인거임)
-                            w2c의 왼쪽 상단 3*3은 회전 R, 3행 0열~2열 : t
-                             => 월드좌표계에서 카메라 좌표계로 변환할 때 사용
-        am_pos:torch.Size([3])
-        tensor([-5.5859e-03, -1.8000e+00, -2.1062e-13], device='cuda:0') 
-        w2c:torch.Size([4, 4])
-        tensor([[ 2.2204e-16,  0.0000e+00, -1.0000e+00,  0.0000e+00],
-                [ 0.0000e+00,  1.0000e+00,  0.0000e+00,  0.0000e+00],
-                [ 1.0000e+00,  0.0000e+00,  2.2204e-16,  0.0000e+00],
-                [ 2.1062e-13,  1.8000e+00, -5.5859e-03,  1.0000e+00]], device='cuda:0')
-        """
-    
-        #print("means: ", means3D.shape, means3D)
-        #test----------------------------------------------------------------
 
         # Rasterize visible Gaussians to image, obtain their radii (on screen).
         rendered_image, radii = rasterizer(
@@ -261,52 +238,54 @@ class CigaRenderer(Renderer):
 
         assert C == 3 and K == (L + 1) ** 2
 
-        # 가시 가우시안 인덱스
-        if self.mlp is None:
-            vis_mask = torch.ones(N, dtype=torch.bool, device=device)
-            vis_idx = torch.arange(N, device=device)
-        else:
+        # 가시 가우시안 인덱스 <- 점검 필요 : 가시 가우시안을 뽑아내지 못하는듯함
+        if isinstance(self.mlp, CigaMLP):
             with torch.no_grad(): vis_mask = rasterizer.markVisible(means3D) # -> (N,) bool 텐서 반환
             vis_idx = torch.where(vis_mask)[0]
+        else:
+            vis_mask = torch.ones(N, dtype=torch.bool, device=device)
+            vis_idx = torch.arange(N, device=device)
             
 
         means3D_vis = means3D[vis_idx]  # 가시 가우시안 좌표
         shs_vis = shs[vis_idx]  # 가시 가우시안 SH 계수
-        
+        print("vis:", vis_idx)
+        print("GT:", N)
         # sh 가중치(MLP 결과)를 담을 더미 텐서
         sh_weight = torch.zeros(N, L+1, C, device=device, dtype=dtype)
 
         if isinstance(self.mlp, CigaMLP):
-            self.mlp.to_input(VC, means3D_vis)
+            d = self.mlp.to_input(VC, means3D_vis)
+            # torch.Size([219439, 3]) torch.Size([219439, 1]) torch.Size([219439, 3])
+            #print(d['cam_pos'].shape, d['dis'].shape, d['dir'].shape)
 
-            sh_weight = self.mlp(
-                # 카메라 좌표
-                # 거리
-                # 방향
-            )
+            x = torch.cat([d['cam_pos'], d['dis'], d['dir']], dim=1)
+            #print("xxx", x.shape) # torch.Size([219439, 7])
+            sh_weight = self.mlp(x)
+
         else:
             print("!!!")
         
         # 밴드별 가중치를 계수별 가중치로 변환
-        #print("shs_weight_MLP:", sh_weight.shape)  # -> shs_weight_MLP: torch.Size([219439, 4, 3])
         sh_weight = self.band_flatten(sh_weight, L)
-
         # sh 계수와 가중치 곱 (MLP 출력 형태에 따라 연산 수정 필요)
-        # shs shape         = [gaussian 수, 3(RGB), (max_sh_degree+1)^2]
-        # sh_weight shape   = [가시 가우시안 수, 3(RGB), max_sh_degree+1]
+        # in        : sh_weight shape   = [가시 가우시안 수, L+1] : L=sh_max_degree
+        #         ▼ band_flatten
+        # return    : sh_weight shape   = [gaussian 수, (L+1)^2, 3(RGB)]
+        
         shs_out = shs.clone()
         shs_out = shs * sh_weight
         return shs_out
 
     def band_flatten(self, sh_weight, L):
         """
-        sh_weight: [N, L+1, 3]
+        sh_weight: [N, L+1]
         반환:      [N, (L+1)^2, 3]
         """
         import torch
 
-        N, B, C = sh_weight.shape
-        assert C == 3 and B == L + 1, f"got {sh_weight.shape}, expected [N,{L+1},3]"
+        N, B = sh_weight.shape
+        assert B == L + 1, f"got {sh_weight.shape}, expected [N,{L+1},3]"
 
         # 각 밴드의 계수 개수: 2l+1  (0차:1, 1차:3, ..., L차:2L+1)
         band_sizes = torch.tensor([2 * l + 1 for l in range(L + 1)],
@@ -321,6 +300,8 @@ class CigaRenderer(Renderer):
         # 밴드 축(dim=1) 기준으로 인덱싱 → [N, K, 3]
         weights_coeff = sh_weight.index_select(dim=1, index=band_of_coeff)
         
+        weights_coeff = weights_coeff.unsqueeze(-1).expand(-1, -1, 3)
+
         return weights_coeff
 
         


### PR DESCRIPTION
- CigaMLP (internal/models/ciga_mlp.py)
  - [x] .to_input / 카메라 위치, 카메라-가우시안 거리, 카메라-가우시안 방향을 구해 딕셔너리로 반환

- CigaRenderer (internal/renderers/ciga_renderer2.py)
  - [x] .band_flatten / 수정: input(sh_weight) shape이 [N, 3, L+1]이 아니라 [N, L+1]이었음. 

##### Issue
CigaRenderer에서 rasterizer.markVisible(means3D) <- 가시 가우시안을 뽑아내지 못하는것 같음 (means3D와 반환값의 크기가 같음)
=>수정예정